### PR TITLE
Added AzureWebJobsFeatureFlags setting to re-enable Proxies on v4 Azure Function App

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -157,6 +157,7 @@
                 "properties": {
                   "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
                   "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
+                  "AzureWebJobsFeatureFlags": "EnableProxies",
                   "FUNCTIONS_EXTENSION_VERSION": "latest",
                   "HOST_NAME": "[concat('http://', parameters('name'), '.', resourceGroup().location, '.azurecontainer.io')]"
                 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Requestbin On Azure Container Instances
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsjkp%2Frequestbininazure%2Fmaster%2Fazuredeploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsjkp%2Frequestbininazure%2Fmaster%2Fazuredeploy.json" target="_blank">![Deploy to Azure](https://aka.ms/deploytoazurebutton)</a>
 
 This repository contains a self-hosted version of requestbin, that run on Azure Container Instances. 
 
@@ -22,5 +22,5 @@ In other words don't let it run 24x7 if you want to do that you are better off i
 ## Accessing the site
 After the template deployment is complete you can access requestbin site using the following urls: 
 
-* If you need https, you have to use `https://<name-specified-during-deployment>.azurewebsites.net`
+* If you need https, you have to use `https://<name-specified-during-deployment>.azurewebsites.net`. However, this will need some additional setup before it will work if you're using version `~4` of Azure Functions, as the proxies feature has been disabled. In order to re-enable it, on the Azure Portal, make sure the app setting `AzureWebJobsFeatureFlags` has the value `EnableProxies`. Although this re-enables the proxies feature, the `Proxies` menu item will remain grayed-out. See [Re-enable proxies in Functions v4.x](https://learn.microsoft.com/en-us/azure/azure-functions/legacy-proxies#re-enable-proxies-in-functions-v4x) for more information. For convenience, this app setting is included in the ARM template.
 * You can also access it using the ACI domain at `http://<name-specified-during-deployment>.<regionname-of-resourcegroup>.azurecontainer.io` where `<regionname-of-resourcegroup>` e.g. could be `westeurope` if you created the resource group in that region. Note this URL doesn't support https, as that is yet to come for ACI, which is why I included the azure function reverse proxy in the template, as you most likely need https. 


### PR DESCRIPTION
Added AzureWebJobsFeatureFlags setting to re-enable Proxies on v4 Azure Function App. Modified readme to explain this.